### PR TITLE
Update decidim/announcement cell call

### DIFF
--- a/app/views/decidim/anonymous_proposals/shared/_anonymous_proposals_announcement.html.erb
+++ b/app/views/decidim/anonymous_proposals/shared/_anonymous_proposals_announcement.html.erb
@@ -1,10 +1,10 @@
 <% unless user_signed_in? %>
   <%= cell(
-            "decidim/announcement",
-            announcement: { I18n.locale => t(
-              ".text_html",
-              registration_link: link_to(t("register", scope: "decidim.anonymous_proposals"), decidim.new_user_registration_path, target: "_blank", class: "external-link-container"),
-              new_session_link: link_to(t("new_session", scope: "decidim.anonymous_proposals"), decidim.new_user_session_path, target: "_blank", class: "external-link-container")
-            ) }
-          ) %>
+    "decidim/announcement",
+    I18n.locale => t(
+      ".text_html",
+      registration_link: link_to(t("register", scope: "decidim.anonymous_proposals"), decidim.new_user_registration_path, target: "_blank", class: "external-link-container"),
+      new_session_link: link_to(t("new_session", scope: "decidim.anonymous_proposals"), decidim.new_user_session_path, target: "_blank", class: "external-link-container")
+    )
+  ) %>
 <% end %>

--- a/app/views/decidim/anonymous_proposals/shared/_anonymous_proposals_new_announcement.html.erb
+++ b/app/views/decidim/anonymous_proposals/shared/_anonymous_proposals_new_announcement.html.erb
@@ -1,10 +1,10 @@
 <% unless user_signed_in? %>
   <%= cell(
-            "decidim/announcement",
-            announcement: { I18n.locale => t(
-              ".text_html",
-              registration_link: link_to(t("register", scope: "decidim.anonymous_proposals"), decidim.new_user_registration_path, target: "_blank", class: "external-link-container"),
-              new_session_link: link_to(t("new_session", scope: "decidim.anonymous_proposals"), decidim.new_user_session_path, target: "_blank", class: "external-link-container")
-            ) }
-          ) %>
+    "decidim/announcement",
+    I18n.locale => t(
+      ".text_html",
+      registration_link: link_to(t("register", scope: "decidim.anonymous_proposals"), decidim.new_user_registration_path, target: "_blank", class: "external-link-container"),
+      new_session_link: link_to(t("new_session", scope: "decidim.anonymous_proposals"), decidim.new_user_session_path, target: "_blank", class: "external-link-container")
+    )
+  ) %>
 <% end %>


### PR DESCRIPTION
With recent changes (decidim/decidim#7568) in decidim, the decidim/announcement call in this module fails. This PR fixes how this cell is called to avoid exceptions