### PR TITLE
Make anonymous proposals configurable per proposal component

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ proposals. For this the proposals created anonymously will be linked with
 a special anonymous users group. There is a task to create/update anonymous
 groups in organizations explained in Installation section.
 
+The creation of anonymous proposals can be disabled for each proposals
+component individually. Once you have installed this module and added an
+anonymous group, anonymous proposals will be enabled by default on all
+proposal components.
 
 ## Installation
 

--- a/app/commands/decidim/anonymous_proposals/create_proposal_command_overrides.rb
+++ b/app/commands/decidim/anonymous_proposals/create_proposal_command_overrides.rb
@@ -8,11 +8,20 @@ module Decidim
 
       def initialize(form, current_user, coauthorships = nil)
         @form = form
-        @current_user = current_user || Decidim::UserGroup.where(organization: organization).anonymous.first
+        @current_user = current_user
+        @current_user ||= anonymous_group if allow_anonymous_proposals?
         @coauthorships = coauthorships
       end
 
       private
+
+      def anonymous_group
+        Decidim::UserGroup.where(organization: organization).anonymous.first
+      end
+
+      def allow_anonymous_proposals?
+        form.current_component.settings.anonymous_proposals_enabled?
+      end
 
       def organization
         @organization ||= form.current_organization

--- a/app/commands/decidim/anonymous_proposals/publish_proposal_command_overrides.rb
+++ b/app/commands/decidim/anonymous_proposals/publish_proposal_command_overrides.rb
@@ -8,7 +8,18 @@ module Decidim
 
       def initialize(proposal, current_user)
         @proposal = proposal
-        @current_user = current_user || Decidim::UserGroup.where(organization: proposal.organization).anonymous.first
+        @current_user = current_user
+        @current_user ||= anonymous_group if allow_anonymous_proposals?
+      end
+
+      private
+
+      def anonymous_group
+        Decidim::UserGroup.where(organization: @proposal.organization).anonymous.first
+      end
+
+      def allow_anonymous_proposals?
+        @proposal.component.settings.anonymous_proposals_enabled?
       end
     end
   end

--- a/app/commands/decidim/anonymous_proposals/update_proposal_command_overrides.rb
+++ b/app/commands/decidim/anonymous_proposals/update_proposal_command_overrides.rb
@@ -8,12 +8,21 @@ module Decidim
 
       def initialize(form, current_user, proposal)
         @form = form
-        @current_user = current_user || Decidim::UserGroup.where(organization: organization).anonymous.first
+        @current_user = current_user
+        @current_user ||= anonymous_group if allow_anonymous_proposals?
         @proposal = proposal
         @attached_to = proposal
       end
 
       private
+
+      def anonymous_group
+        Decidim::UserGroup.where(organization: organization).anonymous.first
+      end
+
+      def allow_anonymous_proposals?
+        form.current_component.settings.anonymous_proposals_enabled?
+      end
 
       def organization
         @organization ||= form.current_organization

--- a/app/controllers/decidim/anonymous_proposals/proposals_controller_additions.rb
+++ b/app/controllers/decidim/anonymous_proposals/proposals_controller_additions.rb
@@ -7,10 +7,14 @@ module Decidim
       extend ActiveSupport::Concern
 
       included do
-        skip_before_action :authenticate_user!, if: :anonymous_group_present?
+        skip_before_action :authenticate_user!, if: :allow_anonymous_proposals?
       end
 
       private
+
+      def allow_anonymous_proposals?
+        anonymous_group_present? && component_settings.anonymous_proposals_enabled?
+      end
 
       def anonymous_group_present?
         Decidim::UserGroup.where(organization: current_organization).anonymous.exists?

--- a/app/permissions/decidim/anonymous_proposals/permissions_overrides.rb
+++ b/app/permissions/decidim/anonymous_proposals/permissions_overrides.rb
@@ -28,7 +28,11 @@ module Decidim
       private
 
       def user_or_anonymous_action?(permission_action)
-        user || [:create, :edit].include?(permission_action.action) && Decidim::UserGroup.where(organization: organization).anonymous.exists?
+        user || [:create, :edit].include?(permission_action.action) && allow_anonymous_proposals?
+      end
+
+      def allow_anonymous_proposals?
+        Decidim::UserGroup.where(organization: organization).anonymous.exists? && component_settings.anonymous_proposals_enabled?
       end
 
       def organization

--- a/app/views/decidim/anonymous_proposals/shared/_anonymous_proposals_announcement.html.erb
+++ b/app/views/decidim/anonymous_proposals/shared/_anonymous_proposals_announcement.html.erb
@@ -1,10 +1,12 @@
 <% unless user_signed_in? %>
-  <%= cell(
-    "decidim/announcement",
-    I18n.locale => t(
-      ".text_html",
-      registration_link: link_to(t("register", scope: "decidim.anonymous_proposals"), decidim.new_user_registration_path, target: "_blank", class: "external-link-container"),
-      new_session_link: link_to(t("new_session", scope: "decidim.anonymous_proposals"), decidim.new_user_session_path, target: "_blank", class: "external-link-container")
-    )
-  ) %>
+  <% if current_settings.creation_enabled && !user_signed_in? && component_settings.anonymous_proposals_enabled? %>
+    <%= cell(
+      "decidim/announcement",
+      I18n.locale => t(
+        ".text_html",
+        registration_link: link_to(t("register", scope: "decidim.anonymous_proposals"), decidim.new_user_registration_path, target: "_blank", class: "external-link-container"),
+        new_session_link: link_to(t("new_session", scope: "decidim.anonymous_proposals"), decidim.new_user_session_path, target: "_blank", class: "external-link-container")
+      )
+    ) %>
+  <% end %>
 <% end %>

--- a/app/views/decidim/anonymous_proposals/shared/_anonymous_proposals_announcement.html.erb
+++ b/app/views/decidim/anonymous_proposals/shared/_anonymous_proposals_announcement.html.erb
@@ -1,12 +1,10 @@
-<% unless user_signed_in? %>
-  <% if current_settings.creation_enabled && !user_signed_in? && component_settings.anonymous_proposals_enabled? %>
-    <%= cell(
-      "decidim/announcement",
-      I18n.locale => t(
-        ".text_html",
-        registration_link: link_to(t("register", scope: "decidim.anonymous_proposals"), decidim.new_user_registration_path, target: "_blank", class: "external-link-container"),
-        new_session_link: link_to(t("new_session", scope: "decidim.anonymous_proposals"), decidim.new_user_session_path, target: "_blank", class: "external-link-container")
-      )
-    ) %>
-  <% end %>
+<% if current_settings.creation_enabled && !user_signed_in? && component_settings.anonymous_proposals_enabled? %>
+  <%= cell(
+    "decidim/announcement",
+    I18n.locale => t(
+      ".text_html",
+      registration_link: link_to(t("register", scope: "decidim.anonymous_proposals"), decidim.new_user_registration_path, target: "_blank", class: "external-link-container"),
+      new_session_link: link_to(t("new_session", scope: "decidim.anonymous_proposals"), decidim.new_user_session_path, target: "_blank", class: "external-link-container")
+    )
+  ) %>
 <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,30 @@
+---
+de:
+  decidim:
+    anonymous_proposals:
+      new_session: loggen Sie sich ein
+      register: Registrieren Sie sich
+      shared:
+        anonymous_proposals_announcement:
+          text_html: "<p><strong> %{registration_link} oder %{new_session_link} damit Sie
+            keine Neuigkeiten des Prozesses verpassen</strong>. Wenn Sie Ihren Vorschlag
+            als registrierten Benutzer veröffentlichen, können Sie anderen Teilnehmern folgen,
+            mit ihnen interagieren, bei allen Vorschlägen kommentieren, am
+            Meinungsaustausch teilnehmen und Ihre Unterstützung für Vorschläge zeigen.
+            Sie können auch entscheiden, ob Sie Benachrichtigungen empfangen wollen wenn
+            jemand ihren Vorschlag unterstützt oder kommentiert. Zusätzlich haben Sie die
+            Möglichkeit, einen Newsletter mit allen Updates zu bekommen.</p> <p><em>“Aber
+            ich möchte nicht dass mein Name erkannt wird”</em>:
+            In diesem Fall können Sie sich mit einem Decknamen registrieren, unter dem Sie
+            Ihren Vorschlag veröffentlichen. So können Sie dennoch alle Vorteile einer
+            Registrierung auf der Plattform geniessen.</p>"
+        anonymous_proposals_new_announcement:
+          text_html: "<p>Möchten Sie dass andere Teilnehmer ihnen folgen und auf Ihren
+            Vorschlag kommentieren? <strong>%{registration_link} oder %{new_session_link}</strong>.</p>"
+    components:
+      proposals:
+        settings:
+          global:
+            anonymous_proposals_enabled: Anonyme Benutzer können Vorschläge erstellen
+      anonymous_proposals:
+        name: AnonymousProposals

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,5 +23,9 @@ en:
             on your proposal?<strong> %{registration_link} or %{new_session_link}
             on the platform</strong>.</p>"
     components:
+      proposals:
+        settings:
+          global:
+            anonymous_proposals_enabled: Allow anonymous users to create proposals
       anonymous_proposals:
         name: AnonymousProposals

--- a/lib/decidim/anonymous_proposals/engine.rb
+++ b/lib/decidim/anonymous_proposals/engine.rb
@@ -16,6 +16,13 @@ module Decidim
         # root to: "anonymous_proposals#index"
       end
 
+      initializer "decidim_anonymous_proposals.proposal_component_settings" do
+        component = Decidim.find_component_manifest(:proposals)
+        component.settings(:global) do |settings|
+          settings.attribute :anonymous_proposals_enabled, type: :boolean, default: true
+        end
+      end
+
       initializer "decidim_anonymous_proposals.assets" do |app|
         app.config.assets.precompile += %w(decidim_anonymous_proposals_manifest.js decidim_anonymous_proposals_manifest.css)
       end


### PR DESCRIPTION
Fixes #3 

I chose to make it a "global" setting as opposed to a setting per "step", since official proposals are also enabled on a global basis, and since assemblies don't have steps. I set the default of the flag to "anonymous proposals are allowed" in order to be backwards-compatible for existing users of the module.

The translations to Spanish and Catalan you will have to do, since I don't speak those languages. I have added a German translation though.

The "New proposal" button is still always displayed, but will lead to the login screen in proposal components that disallow anonymous proposals. The announcement banner above the button is only displayed when anonymous proposals are allowed and creatable right now.
I also discovered a bug: In organizations that have no anonymous group defined, the "New proposal" button and the announcement are still displayed for anonymous users. But I think that should go into a separate issue, would you agree?