### PR TITLE
Anonymous proposals for registered users

### DIFF
--- a/app/commands/decidim/anonymous_proposals/anonymous_behavior_commands_concern.rb
+++ b/app/commands/decidim/anonymous_proposals/anonymous_behavior_commands_concern.rb
@@ -1,0 +1,33 @@
+module Decidim
+  module AnonymousProposals
+    module AnonymousBehaviorCommandsConcern
+      private
+
+      def is_anonymous?
+        @is_anonymous
+      end
+
+      def anonymous_group
+        Decidim::UserGroup.where(organization: organization).anonymous.first
+      end
+
+      def set_current_user(user)
+        @current_user = is_anonymous? ? anonymous_group : user
+      end
+
+      def user_group
+        return if is_anonymous?
+
+        @selected_user_group
+      end
+
+      def allow_anonymous_proposals?
+        component.settings.anonymous_proposals_enabled?
+      end
+
+      def organization
+        @organization ||= component.organization
+      end
+    end
+  end
+end

--- a/app/commands/decidim/anonymous_proposals/publish_proposal_command_overrides.rb
+++ b/app/commands/decidim/anonymous_proposals/publish_proposal_command_overrides.rb
@@ -6,20 +6,18 @@ module Decidim
     module PublishProposalCommandOverrides
       extend ActiveSupport::Concern
 
+      include Decidim::AnonymousProposals::AnonymousBehaviorCommandsConcern
+
       def initialize(proposal, current_user)
         @proposal = proposal
-        @current_user = current_user
-        @current_user ||= anonymous_group if allow_anonymous_proposals?
+        @is_anonymous = allow_anonymous_proposals? && (current_user.blank? || proposal.authored_by?(anonymous_group))
+        set_current_user(current_user)
       end
 
       private
 
-      def anonymous_group
-        Decidim::UserGroup.where(organization: @proposal.organization).anonymous.first
-      end
-
-      def allow_anonymous_proposals?
-        @proposal.component.settings.anonymous_proposals_enabled?
+      def component
+        @component ||= @proposal.component
       end
     end
   end

--- a/app/commands/decidim/anonymous_proposals/update_proposal_command_overrides.rb
+++ b/app/commands/decidim/anonymous_proposals/update_proposal_command_overrides.rb
@@ -13,7 +13,8 @@ module Decidim
         @selected_user_group = Decidim::UserGroup.find_by(organization: organization, id: form.user_group_id)
         @proposal = proposal
         @attached_to = proposal
-        @is_anonymous = allow_anonymous_proposals? && (current_user.blank? || proposal.authored_by?(anonymous_group))
+        @editable = allow_anonymous_proposals? && proposal.authored_by?(anonymous_group) || proposal.editable_by?(current_user)
+        @is_anonymous = allow_anonymous_proposals? && (current_user.blank? || (proposal.published? ? proposal.authored_by?(anonymous_group) : @selected_user_group == anonymous_group))
         set_current_user(current_user)
       end
 
@@ -21,6 +22,10 @@ module Decidim
 
       def component
         @component ||= form.current_component
+      end
+
+      def invalid?
+        !@editable || form.invalid? || proposal_limit_reached?
       end
     end
   end

--- a/app/commands/decidim/anonymous_proposals/update_proposal_command_overrides.rb
+++ b/app/commands/decidim/anonymous_proposals/update_proposal_command_overrides.rb
@@ -6,26 +6,21 @@ module Decidim
     module UpdateProposalCommandOverrides
       extend ActiveSupport::Concern
 
+      include Decidim::AnonymousProposals::AnonymousBehaviorCommandsConcern
+
       def initialize(form, current_user, proposal)
         @form = form
-        @current_user = current_user
-        @current_user ||= anonymous_group if allow_anonymous_proposals?
+        @selected_user_group = Decidim::UserGroup.find_by(organization: organization, id: form.user_group_id)
         @proposal = proposal
         @attached_to = proposal
+        @is_anonymous = allow_anonymous_proposals? && (current_user.blank? || proposal.authored_by?(anonymous_group))
+        set_current_user(current_user)
       end
 
       private
 
-      def anonymous_group
-        Decidim::UserGroup.where(organization: organization).anonymous.first
-      end
-
-      def allow_anonymous_proposals?
-        form.current_component.settings.anonymous_proposals_enabled?
-      end
-
-      def organization
-        @organization ||= form.current_organization
+      def component
+        @component ||= form.current_component
       end
     end
   end

--- a/app/controllers/decidim/anonymous_proposals/proposals_controller_additions.rb
+++ b/app/controllers/decidim/anonymous_proposals/proposals_controller_additions.rb
@@ -7,13 +7,23 @@ module Decidim
       extend ActiveSupport::Concern
 
       included do
+        helper_method :allow_anonymous_proposals?, :is_anonymous?, :anonymous_group
+
         skip_before_action :authenticate_user!, if: :allow_anonymous_proposals?
       end
 
       private
 
       def allow_anonymous_proposals?
-        anonymous_group_present? && component_settings.anonymous_proposals_enabled?
+        anonymous_group.present? && component_settings.anonymous_proposals_enabled?
+      end
+
+      def is_anonymous?
+        allow_anonymous_proposals? && (current_user.blank? || @proposal&.authored_by?(anonymous_group))
+      end
+
+      def anonymous_group
+        @anonymous_group ||= Decidim::UserGroup.where(organization: current_organization).anonymous.first
       end
 
       def anonymous_group_present?

--- a/app/helpers/decidim/anonymous_proposals/user_group_helper.rb
+++ b/app/helpers/decidim/anonymous_proposals/user_group_helper.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Decidim
+  module AnonymousProposals
+    # Custom helpers, scoped to the anonymous_proposals engine.
+    #
+    module UserGroupHelper
+      # Renders a user_group select field in a form including the anonymous
+      # option if enabled
+      # form - FormBuilder object
+      # name - attribute user_group_id
+      # options - A hash used to modify the behavior of the select field.
+      #
+      # Returns nothing.
+      def user_group_with_anonymous_select_field(form, name, options = {})
+        return unless user_signed_in?
+        return user_group_select_field(form, name, options) unless allow_anonymous_proposals?
+
+        user_groups = Decidim::UserGroups::ManageableUserGroups.for(current_user).verified
+        anonymous_group_extension = anonymous_group.present? ? [[t("anonymous_user", scope: "decidim.proposals.proposals.new"), anonymous_group.id]] : []
+
+        form.select(
+          name,
+          user_groups.map { |g| [g.name, g.id] } + anonymous_group_extension,
+          selected: @form.user_group_id.presence,
+          include_blank: current_user.name,
+          label: options.has_key?(:label) ? options[:label] : true
+        )
+      end
+    end
+  end
+end

--- a/app/helpers/decidim/anonymous_proposals/user_group_helper.rb
+++ b/app/helpers/decidim/anonymous_proposals/user_group_helper.rb
@@ -14,18 +14,23 @@ module Decidim
       # Returns nothing.
       def user_group_with_anonymous_select_field(form, name, options = {})
         return unless user_signed_in?
-        return user_group_select_field(form, name, options) unless allow_anonymous_proposals?
 
         user_groups = Decidim::UserGroups::ManageableUserGroups.for(current_user).verified
-        anonymous_group_extension = anonymous_group.present? ? [[t("anonymous_user", scope: "decidim.proposals.proposals.new"), anonymous_group.id]] : []
 
-        form.select(
-          name,
-          user_groups.map { |g| [g.name, g.id] } + anonymous_group_extension,
-          selected: @form.user_group_id.presence,
-          include_blank: current_user.name,
-          label: options.has_key?(:label) ? options[:label] : true
-        )
+        if allow_anonymous_proposals?
+          anonymous_group_extension = anonymous_group.present? ? [[t("anonymous_user", scope: "decidim.proposals.proposals.new"), anonymous_group.id]] : []
+          selected_group_id = (@form.user_group_id || options[:select_anonymous] && anonymous_group&.id).presence
+
+          form.select(
+            name,
+            user_groups.map { |g| [g.name, g.id] } + anonymous_group_extension,
+            selected: selected_group_id,
+            include_blank: current_user.name,
+            label: options.has_key?(:label) ? options[:label] : true
+          )
+        else
+          return user_group_select_field(form, name, options) if current_organization.user_groups_enabled? && user_groups.any?
+        end
       end
     end
   end

--- a/app/models/concerns/decidim/anonymous_proposals/coauthorable_overrides.rb
+++ b/app/models/concerns/decidim/anonymous_proposals/coauthorable_overrides.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Decidim
+  module AnonymousProposals
+    module CoauthorableOverrides
+      extend ActiveSupport::Concern
+
+      included do
+        def add_coauthor(author, extra_attributes = {})
+          return if author.blank? && persisted?
+          user_group = extra_attributes[:user_group]
+
+          if allow_anonymous_proposals? && (author.blank? || user_group == anonymous_group)
+            author = anonymous_group
+            user_group = nil
+            extra_attributes.delete(:user_group)
+          end
+
+          return if coauthorships.exists?(decidim_author_id: author.id, decidim_author_type: author.class.base_class.name) && user_group.blank?
+          return if user_group && coauthorships.exists?(user_group: user_group)
+
+          coauthorship_attributes = extra_attributes.merge(author: author)
+
+          if persisted?
+            coauthorships.create!(coauthorship_attributes)
+          else
+            coauthorships.build(coauthorship_attributes)
+          end
+
+          authors << author
+        end
+
+        private
+
+        def allow_anonymous_proposals?
+          component.settings.anonymous_proposals_enabled?
+        end
+
+        def anonymous_group
+          Decidim::UserGroup.where(organization: organization).anonymous.first
+        end
+      end
+    end
+  end
+end

--- a/app/overrides/decidim/proposals/proposals/_edit_form_fields/remove_group_select.html.erb.deface
+++ b/app/overrides/decidim/proposals/proposals/_edit_form_fields/remove_group_select.html.erb.deface
@@ -1,3 +1,1 @@
-<!-- replace "erb[silent]:contains('if current_organization.user_groups_enabled?')" -->
-
-<% if !is_anonymous? && current_organization.user_groups_enabled? && Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
+<!-- remove "erb[loud]:contains('user_group_select_field form, :user_group_id')" -->

--- a/app/overrides/decidim/proposals/proposals/_edit_form_fields/remove_group_select.html.erb.deface
+++ b/app/overrides/decidim/proposals/proposals/_edit_form_fields/remove_group_select.html.erb.deface
@@ -1,0 +1,3 @@
+<!-- replace "erb[silent]:contains('if current_organization.user_groups_enabled?')" -->
+
+<% if !is_anonymous? && current_organization.user_groups_enabled? && Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>

--- a/app/overrides/decidim/proposals/proposals/_edit_form_fields/update_group_select.html.erb.deface
+++ b/app/overrides/decidim/proposals/proposals/_edit_form_fields/update_group_select.html.erb.deface
@@ -1,0 +1,14 @@
+<!-- replace "erb[silent]:contains('if current_organization.user_groups_enabled?')" -->
+
+<% if current_organization.user_groups_enabled? && Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
+  <% if @proposal.draft? %>
+    <div class="field">
+      <%= user_group_with_anonymous_select_field form, :user_group_id, select_anonymous: @proposal.persisted? && is_anonymous? %>
+    </div>
+  <% else %>
+    <% if !is_anonymous? %>
+      <div class="field">
+        <%= user_group_select_field form, :user_group_id %>
+      </div>
+    <% end %>
+  <% end %>

--- a/app/overrides/decidim/proposals/proposals/_wizard_header/contextual_info.html.erb.deface
+++ b/app/overrides/decidim/proposals/proposals/_wizard_header/contextual_info.html.erb.deface
@@ -1,4 +1,4 @@
 <!-- insert_before "h2" -->
-<% if @step == :step_1 %>
+<% if [:step_1, :step_3].include?(@step) %>
   <%= render partial: "decidim/anonymous_proposals/shared/anonymous_proposals_new_announcement" %>
 <% end %>

--- a/app/overrides/decidim/proposals/proposals/new/create_as_anonymous_user.html.erb.deface
+++ b/app/overrides/decidim/proposals/proposals/new/create_as_anonymous_user.html.erb.deface
@@ -1,0 +1,5 @@
+<!-- insert_before "div.card div.actions" original "ac833c6738922b1b30e2240aa17dd45a1e5cef5e" -->
+
+<div class="field">
+  <%= user_group_with_anonymous_select_field form, :user_group_id %>
+</div>

--- a/app/overrides/decidim/proposals/proposals/new/create_as_anonymous_user.html.erb.deface
+++ b/app/overrides/decidim/proposals/proposals/new/create_as_anonymous_user.html.erb.deface
@@ -1,4 +1,4 @@
-<!-- insert_before "div.card div.actions" original "ac833c6738922b1b30e2240aa17dd45a1e5cef5e" -->
+<!-- insert_before "div.card div.actions" -->
 
 <div class="field">
   <%= user_group_with_anonymous_select_field form, :user_group_id %>

--- a/app/overrides/decidim/proposals/proposals/new/remove_group_select.html.erb.deface
+++ b/app/overrides/decidim/proposals/proposals/new/remove_group_select.html.erb.deface
@@ -1,1 +1,1 @@
-<!-- remove "erb[loud]:contains('user_group_select_field form, :user_group_id')" original "ea82cc8a19cf272a5c085df8fcdff3fe65965dca" -->
+<!-- remove "erb[loud]:contains('user_group_select_field form, :user_group_id')" -->

--- a/app/overrides/decidim/proposals/proposals/new/remove_group_select.html.erb.deface
+++ b/app/overrides/decidim/proposals/proposals/new/remove_group_select.html.erb.deface
@@ -1,0 +1,1 @@
+<!-- remove "erb[loud]:contains('user_group_select_field form, :user_group_id')" original "ea82cc8a19cf272a5c085df8fcdff3fe65965dca" -->

--- a/app/packs/entrypoints/decidim_anonymous_proposals.js
+++ b/app/packs/entrypoints/decidim_anonymous_proposals.js
@@ -1,2 +1,4 @@
+import "src/decidim/decidim-anonymous_proposals/form_autosave"
+
 // Images
 require.context("../images", true)

--- a/app/packs/src/decidim/decidim-anonymous_proposals/form_autosave.js
+++ b/app/packs/src/decidim/decidim-anonymous_proposals/form_autosave.js
@@ -1,0 +1,60 @@
+$(() => {
+  const currentComponentId = window.DecidimAnonymousProposals.currentComponentId;
+  if (!currentComponentId) {
+    return;
+  }
+
+  const titleStoreId = `new_proposal:title:${currentComponentId}`;
+  const bodyStoreId = `new_proposal:body:${currentComponentId}`;
+  const $form = $("form.new_proposal");
+
+  if (!$form.length) {
+    window.localStorage.removeItem(titleStoreId);
+    window.localStorage.removeItem(bodyStoreId);
+    return;
+  } else {
+    const titleStored = window.localStorage.getItem(titleStoreId);
+    const bodyStored = window.localStorage.getItem(bodyStoreId);
+
+    const $title = $form.find("#proposal_title");
+    const $body = $form.find("#proposal_body");
+
+    const save = () => {
+      const titleVal = $title.val();
+      const bodyVal = $body.val();
+
+      if (titleVal.length > 0) {
+        window.localStorage.setItem(titleStoreId, $title.val());
+      }
+
+      if (bodyVal.length > 0) {
+        window.localStorage.setItem(bodyStoreId, $body.val());
+      }
+    }
+
+    if(titleStored) {
+      $title.val(titleStored);
+    } else {
+      save();
+    }
+
+    if(bodyStored) {
+      $body.val(bodyStored);
+    } else {
+      save();
+    }
+
+    $title.on("change", () => {
+      save();
+    });
+
+    $body.on("change", () => {
+      save();
+    });
+
+    $form.on("formvalid.zf.abide", function() {
+      window.localStorage.removeItem(titleStoreId);
+      window.localStorage.removeItem(bodyStoreId);
+    });
+  }
+});

--- a/app/permissions/decidim/anonymous_proposals/permissions_overrides.rb
+++ b/app/permissions/decidim/anonymous_proposals/permissions_overrides.rb
@@ -44,7 +44,7 @@ module Decidim
       end
 
       def anonymously_editable?
-        allow_anonymous_proposals? && proposal.editable_by?(Decidim::UserGroup.where(organization: organization).anonymous.first)
+        allow_anonymous_proposals? && proposal.draft? && proposal.editable_by?(Decidim::UserGroup.where(organization: organization).anonymous.first)
       end
     end
   end

--- a/app/views/decidim/anonymous_proposals/shared/_anonymous_proposals_new_announcement.html.erb
+++ b/app/views/decidim/anonymous_proposals/shared/_anonymous_proposals_new_announcement.html.erb
@@ -1,3 +1,4 @@
+<%= javascript_pack_tag "decidim_anonymous_proposals" %>
 <% unless user_signed_in? %>
   <%= cell(
     "decidim/announcement",
@@ -8,3 +9,8 @@
     )
   ) %>
 <% end %>
+
+<script>
+  window.DecidimAnonymousProposals = {};
+  window.DecidimAnonymousProposals.currentComponentId = "<%= current_component.id %>";
+</script>

--- a/config/assets.rb
+++ b/config/assets.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# This file is located at `config/assets.rb` of your module.
+
+# Define the base path of your module. Please note that `Rails.root` may not be
+# used because we are not inside the Rails environment when this file is loaded.
+base_path = File.expand_path("..", __dir__)
+
+# Register an additional load path for webpack. All the assets within these
+# directories will be available for inclusion within the Decidim assets. For
+# example, if you have `app/packs/src/decidim/foo.js`, you can include that file
+# in your JavaScript entrypoints (or other JavaScript files within Decidim)
+# using `import "src/decidim/foo"` after you have registered the additional path
+# as follows.
+Decidim::Webpacker.register_path("#{base_path}/app/packs")
+
+# Register the entrypoints for your module. These entrypoints can be included
+# within your application using `javascript_pack_tag` and if you include any
+# SCSS files within the entrypoints, they become available for inclusion using
+# `stylesheet_pack_tag`.
+Decidim::Webpacker.register_entrypoints(
+  decidim_anonymous_proposals: "#{base_path}/app/packs/entrypoints/decidim_anonymous_proposals.js"
+)
+
+# If you want to import some extra SCSS files in the Decidim main SCSS file
+# without adding any extra stylesheet inclusion tags, you can use the following
+# method to register the stylesheet import for the main application.
+# Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/decidim_awesome/awesome_application")
+
+# If you want to do the same but include the SCSS file for the admin panel's
+# main SCSS file, you can use the following method.
+# Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/foo/admin", group: :admin)
+
+# If you want to override some SCSS variables/settings for Foundation from the
+# module, you can add the following registered import.
+# Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/foo/settings", type: :settings)
+
+# If you want to do the same but override the SCSS variables of the admin
+# panel's styles, you can use the following method.
+# Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/foo/admin_settings", type: :settings, group: :admin)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,3 +29,7 @@ en:
         settings:
           global:
             anonymous_proposals_enabled: Allow anonymous users to create proposals
+    proposals:
+      proposals:
+        new:
+          anonymous_user: "Anonymous user"

--- a/lib/decidim/anonymous_proposals/engine.rb
+++ b/lib/decidim/anonymous_proposals/engine.rb
@@ -19,7 +19,7 @@ module Decidim
       initializer "decidim_anonymous_proposals.proposal_component_settings" do
         component = Decidim.find_component_manifest(:proposals)
         component.settings(:global) do |settings|
-          settings.attribute :anonymous_proposals_enabled, type: :boolean, default: true
+          settings.attribute :anonymous_proposals_enabled, type: :boolean, default: false
         end
       end
 

--- a/lib/decidim/anonymous_proposals/engine.rb
+++ b/lib/decidim/anonymous_proposals/engine.rb
@@ -33,6 +33,10 @@ module Decidim
             prepend Decidim::AnonymousProposals::PermissionsOverrides
           end
 
+          Decidim::Proposals::ProposalsHelper.class_eval do
+            include Decidim::AnonymousProposals::UserGroupHelper
+          end
+
           Decidim::Proposals::ProposalsController.class_eval do
             prepend Decidim::AnonymousProposals::ProposalsControllerOverrides
             include Decidim::AnonymousProposals::ProposalsControllerAdditions

--- a/lib/decidim/anonymous_proposals/engine.rb
+++ b/lib/decidim/anonymous_proposals/engine.rb
@@ -61,6 +61,10 @@ module Decidim
           Decidim::Proposals::PublishProposal.class_eval do
             prepend Decidim::AnonymousProposals::PublishProposalCommandOverrides
           end
+
+          Decidim::Proposals::DestroyProposal.class_eval do
+            prepend Decidim::AnonymousProposals::PublishProposalCommandOverrides
+          end
         end
       end
     end

--- a/lib/decidim/anonymous_proposals/engine.rb
+++ b/lib/decidim/anonymous_proposals/engine.rb
@@ -29,6 +29,10 @@ module Decidim
             include Decidim::AnonymousProposals::HasAnonymous
           end
 
+          Decidim::Proposals::Proposal.class_eval do
+            include Decidim::AnonymousProposals::CoauthorableOverrides
+          end
+
           Decidim::Proposals::Permissions.class_eval do
             prepend Decidim::AnonymousProposals::PermissionsOverrides
           end


### PR DESCRIPTION
Fixes PopulateTools/issues#1894

This PR adds the following changes to the anonymous proposals feature:

* [x] Allows signed in users to create, update and publish anonymous proposals. Once the proposal is created as anonymous the draft edition is allowed but the authorship cannot be changed. Also an existing proposal with an author can't be transformed to anonymous (PopulateTools/decidim-module-anonymous_proposals#14)
* [x] Changes the default value of anonymous proposals setting and disabling the feature on new proposals components (PopulateTools/decidim-module-anonymous_proposals#13)
* [x] Adds some javascript to keep the title and body of new proposals recovering the value when the user is signed in registered, or signed out. The change affects to plain text body input and rich text editor if enabled (PopulateTools/decidim-module-anonymous_proposals#15)

Test the feature in https://decidim-dev-27.populate.tools/processes/new-process/f/14/ and select a municipality scope for the proposal, some bug is preventing the creation of proposals in the proposals components of the other participatory process (something related with the absence of a scope in the space)

[Screencast from 31-01-24 19:05:29.webm](https://github.com/PopulateTools/decidim-module-anonymous_proposals/assets/446459/a52c1b11-00d1-4215-b809-85d3999ab42c)
