### PR TITLE
Release/0.28 stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ proposal components.
 
 Add this line to your application's Gemfile:
 
+For Decidim 0.28:
+```ruby
+gem "decidim-anonymous_proposals", git: "https://github.com/PopulateTools/decidim-module-anonymous_proposals", branch: "release/0.28-stable"
+```
+
 For Decidim 0.27:
 ```ruby
 gem "decidim-anonymous_proposals", git: "https://github.com/PopulateTools/decidim-module-anonymous_proposals", branch: "release/0.27-stable"

--- a/app/overrides/decidim/proposals/proposals/complete/contextual_info.html.erb.deface
+++ b/app/overrides/decidim/proposals/proposals/complete/contextual_info.html.erb.deface
@@ -1,0 +1,4 @@
+<!-- insert_before "erb[loud]:contains('decidim_form_for(@form')" -->
+<% if @step == :step_3 %>
+  <%= render partial: "decidim/anonymous_proposals/shared/anonymous_proposals_new_announcement" %>
+<% end %>

--- a/app/overrides/decidim/proposals/proposals/edit_draft/contextual_info.html.erb.deface
+++ b/app/overrides/decidim/proposals/proposals/edit_draft/contextual_info.html.erb.deface
@@ -1,0 +1,4 @@
+<!-- insert_before "erb[loud]:contains('decidim_form_for(@form')" -->
+<% if @step == :step_3 %>
+  <%= render partial: "decidim/anonymous_proposals/shared/anonymous_proposals_new_announcement" %>
+<% end %>

--- a/app/overrides/decidim/proposals/proposals/index/contextual_info.html.erb.deface
+++ b/app/overrides/decidim/proposals/proposals/index/contextual_info.html.erb.deface
@@ -1,2 +1,2 @@
-<!-- insert_before "div.row.columns" -->
+<!-- insert_before "#proposals" -->
 <%= render partial: "decidim/anonymous_proposals/shared/anonymous_proposals_announcement" %>

--- a/app/overrides/decidim/proposals/proposals/index/new_anonymous_proposal.html.erb.deface
+++ b/app/overrides/decidim/proposals/proposals/index/new_anonymous_proposal.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- replace "erb[loud]:contains('new_proposal_path')" -->
-<%= link_to new_proposal_path, class: "title-action__action button small", data: { "redirect_url" => new_proposal_path } do %>
+<%= link_to new_proposal_path, class: "button button__xl button__secondary w-full", data: { "redirect_url" => new_proposal_path } do %>

--- a/app/overrides/decidim/proposals/proposals/new/contextual_info.html.erb.deface
+++ b/app/overrides/decidim/proposals/proposals/new/contextual_info.html.erb.deface
@@ -1,4 +1,4 @@
-<!-- insert_before "h2" -->
-<% if [:step_1, :step_3].include?(@step) %>
+<!-- insert_before "erb[loud]:contains('decidim_form_for(@form')" -->
+<% if @step == :step_1 %>
   <%= render partial: "decidim/anonymous_proposals/shared/anonymous_proposals_new_announcement" %>
 <% end %>

--- a/app/overrides/decidim/proposals/proposals/new/create_as_anonymous_user.html.erb.deface
+++ b/app/overrides/decidim/proposals/proposals/new/create_as_anonymous_user.html.erb.deface
@@ -1,4 +1,4 @@
-<!-- insert_before "div.card div.actions" -->
+<!-- insert_before "div.form__wrapper-block" -->
 
 <div class="form__wrapper">
   <%= user_group_with_anonymous_select_field form, :user_group_id %>

--- a/app/overrides/decidim/proposals/proposals/new/create_as_anonymous_user.html.erb.deface
+++ b/app/overrides/decidim/proposals/proposals/new/create_as_anonymous_user.html.erb.deface
@@ -1,5 +1,5 @@
 <!-- insert_before "div.card div.actions" -->
 
-<div class="field">
+<div class="form__wrapper">
   <%= user_group_with_anonymous_select_field form, :user_group_id %>
 </div>

--- a/app/packs/src/decidim/decidim-anonymous_proposals/form_autosave.js
+++ b/app/packs/src/decidim/decidim-anonymous_proposals/form_autosave.js
@@ -17,15 +17,15 @@ $(() => {
   } else {
     const $title = $form.find("#proposal_title");
     const $body = $form.find("#proposal_body");
-    const editorContainer = document.querySelector(".editor-container");
-    const editor = editorContainer ? Quill.find(editorContainer) : null;
+    const $editorBody = $form.find(".tiptap.ProseMirror");
+    const editor = $editorBody.length > 0
 
     const titleStored = window.localStorage.getItem(titleStoreId);
     const bodyStored = editor ? window.localStorage.getItem(bodyEditorStoreId) : window.localStorage.getItem(bodyStoreId);
 
     const save = () => {
       const titleVal = $title.val();
-      const bodyVal = editor ? JSON.stringify(editor.getContents()) : $body.val();
+      const bodyVal = editor ? $editorBody.html() : $body.val();
 
       if (titleVal.length > 0) {
         window.localStorage.setItem(titleStoreId, titleVal);
@@ -43,7 +43,7 @@ $(() => {
     }
 
     if(bodyStored) {
-      editor ? editor.setContents(JSON.parse(bodyStored)) : $body.val(bodyStored);
+      editor ? $editorBody.html(bodyStored) : $body.val(bodyStored);
     } else {
       save();
     }
@@ -53,7 +53,7 @@ $(() => {
     });
 
     if (editor) {
-      editor.on(Quill.events.TEXT_CHANGE, (delta, source) => {
+      $editorBody.on("input", () => {
         save();
       });
     }  else {

--- a/app/views/decidim/anonymous_proposals/shared/_anonymous_proposals_announcement.html.erb
+++ b/app/views/decidim/anonymous_proposals/shared/_anonymous_proposals_announcement.html.erb
@@ -1,10 +1,13 @@
 <% if current_settings.creation_enabled && !user_signed_in? && component_settings.anonymous_proposals_enabled? %>
   <%= cell(
     "decidim/announcement",
-    I18n.locale => t(
-      ".text_html",
-      registration_link: link_to(t("register", scope: "decidim.anonymous_proposals"), decidim.new_user_registration_path, target: "_blank", class: "external-link-container"),
-      new_session_link: link_to(t("new_session", scope: "decidim.anonymous_proposals"), decidim.new_user_session_path, target: "_blank", class: "external-link-container")
-    )
+    {
+      I18n.locale => t(
+        ".text_html",
+        registration_link: link_to(t("register", scope: "decidim.anonymous_proposals"), decidim.new_user_registration_path, target: "_blank", class: "external-link-container"),
+        new_session_link: link_to(t("new_session", scope: "decidim.anonymous_proposals"), decidim.new_user_session_path, target: "_blank", class: "external-link-container")
+      )
+    },
+    callout_class: "warning"
   ) %>
 <% end %>

--- a/app/views/decidim/anonymous_proposals/shared/_anonymous_proposals_new_announcement.html.erb
+++ b/app/views/decidim/anonymous_proposals/shared/_anonymous_proposals_new_announcement.html.erb
@@ -1,12 +1,15 @@
-<%= javascript_pack_tag "decidim_anonymous_proposals" %>
+<%= append_javascript_pack_tag "decidim_anonymous_proposals" %>
 <% unless user_signed_in? %>
   <%= cell(
     "decidim/announcement",
-    I18n.locale => t(
-      ".text_html",
-      registration_link: link_to(t("register", scope: "decidim.anonymous_proposals"), decidim.new_user_registration_path, target: "_blank", class: "external-link-container"),
-      new_session_link: link_to(t("new_session", scope: "decidim.anonymous_proposals"), decidim.new_user_session_path, target: "_blank", class: "external-link-container")
-    )
+    {
+      I18n.locale => t(
+        ".text_html",
+        registration_link: link_to(t("register", scope: "decidim.anonymous_proposals"), decidim.new_user_registration_path, target: "_blank", class: "external-link-container"),
+        new_session_link: link_to(t("new_session", scope: "decidim.anonymous_proposals"), decidim.new_user_session_path, target: "_blank", class: "external-link-container")
+      )
+    },
+    callout_class: "warning"
   ) %>
 <% end %>
 


### PR DESCRIPTION
This PR based on `anonymous_proposals_for_registered_users`  branch makes the changes required to work with 2.28 Decidim release.

To do this:
* Adapts styles and structure of some elements specific of the feature to the 0.28 redesign of proposals:
  * Announcement boxes
  * New proposal button
  * User group select field position
* Adapts the autosave form feature using local storage when rich editor is enabled to use tiptap editor instead of deprecated Quill editor

This version is compatible with the simple proposals and decidim_awesome modules in their current 'develop' branches. Note that the proposals functionality is currently disabled in the awesome module. It may happen that in the future there will be some type of incompatibility

The module with the other 2 active can be checked there: https://decidim-redesign.populate.tools/processes/Decidim4Dummies/f/2016/proposals
